### PR TITLE
Fix bug that distorted photo UI on physical devices.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -39,7 +39,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/samsoya/cameroonapp/CameraPreview.java
+++ b/app/src/main/java/samsoya/cameroonapp/CameraPreview.java
@@ -58,6 +58,7 @@ public class CameraPreview extends SurfaceView implements SurfaceHolder.Callback
 
         // start preview with new settings
         try {
+            mCamera.setDisplayOrientation(90);
             mCamera.setPreviewDisplay(mHolder);
             mCamera.startPreview();
 

--- a/app/src/main/java/samsoya/cameroonapp/ConfirmPhotoActivity.java
+++ b/app/src/main/java/samsoya/cameroonapp/ConfirmPhotoActivity.java
@@ -3,6 +3,7 @@ package samsoya.cameroonapp;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -23,9 +24,13 @@ public class ConfirmPhotoActivity extends AppCompatActivity {
         FirebaseApp.initializeApp(this);
         setContentView(R.layout.activity_confirm_photo);
 
-        final byte[] photo = getIntent().getByteArrayExtra(getString(R.string.photo_extra));
+        final byte[] photo = PicturePreviewHolder.getInstance().getCapturedPhotoData();
         final Bitmap photoBitmap = BitmapFactory.decodeByteArray(photo, 0, photo.length);
-        ((ImageView) findViewById(R.id.preview_photo_view)).setImageBitmap(photoBitmap);
+        Matrix matrix = new Matrix();
+        matrix.postRotate(90);
+        ImageView preview = findViewById(R.id.preview_photo_view);
+        final Bitmap rotatedBitmap = Bitmap.createBitmap(photoBitmap, 0, 0, photoBitmap.getWidth(), photoBitmap.getHeight(), matrix, true);
+        ((ImageView) findViewById(R.id.preview_photo_view)).setImageBitmap(rotatedBitmap);
 
         findViewById(R.id.retake_photo_button).setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/samsoya/cameroonapp/PicturePreviewHolder.java
+++ b/app/src/main/java/samsoya/cameroonapp/PicturePreviewHolder.java
@@ -1,0 +1,28 @@
+package samsoya.cameroonapp;
+
+public final class PicturePreviewHolder {
+
+    private static PicturePreviewHolder sInstance;
+    private byte[] mCapturedPhotoData;
+
+    // Getters & Setters
+    public byte[] getCapturedPhotoData() {
+        return mCapturedPhotoData;
+    }
+
+    public void setCapturedPhotoData(byte[] capturedPhotoData) {
+        mCapturedPhotoData = capturedPhotoData;
+    }
+
+    // Singleton code
+    public static PicturePreviewHolder getInstance() {
+        if (sInstance == null) {
+            sInstance = new PicturePreviewHolder();
+        }
+        return sInstance;
+    }
+
+    public void onCreate() {
+        sInstance = this;
+    }
+}

--- a/app/src/main/java/samsoya/cameroonapp/TakePhotoActivity.java
+++ b/app/src/main/java/samsoya/cameroonapp/TakePhotoActivity.java
@@ -42,12 +42,11 @@ public class TakePhotoActivity extends AppCompatActivity {
 
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
-                photoBytes = data;
                 camera.stopPreview();
                 camera.release();
-                Intent intentWithPictureData = new Intent(TakePhotoActivity.this, ConfirmPhotoActivity.class);
-                intentWithPictureData.putExtra(getString(R.string.photo_extra), photoBytes);
-                startActivity(intentWithPictureData);
+                PicturePreviewHolder.getInstance().setCapturedPhotoData(data);
+                Intent intent = new Intent(TakePhotoActivity.this, ConfirmPhotoActivity.class);
+                startActivity(intent);
             }
         };
         takePhotoButton.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
On physical devices, the photos would appear distorted and sideways. Additionally, when attempting to pass high-quality photos through activities, it could crash. We added safeguards to this behavior -- it should no longer occur.